### PR TITLE
Fix an issue where the extension breaks the YouTube feature of blocking users.

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -46,7 +46,7 @@ const checkComment = async node => {
     (!isRegexEnabled && keywordList.some(pattern => message.includes(pattern))) ||
     (!!isRegexEnabled && keywordList.some(pattern => new RegExp(pattern).test(message)))
   ) {
-    node.remove();
+    node.hidden = true;
   }
 };
 


### PR DESCRIPTION
close #3

The issue is probably because the extension removes DOM elements, which might break some references and result in blocking wrong users.